### PR TITLE
Add script to build unified version

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,14 @@ $ q lint.q
 Loads package & lints `.req` & related namespaces. Some errors/warnings
 excluded. Adding an additional arg on cmd line will halt process to inspect
 output table `t`.
+
+## Building releases
+
+To build a release, `build.sh` is used. The script creates the unified, standalone
+`.q` script & the `.tar.gz` of qutil package.
+
+Argument is version number e.g.
+
+```bash
+$ ./build.sh 0.1.3
+```

--- a/README.md
+++ b/README.md
@@ -3,80 +3,61 @@
 [![Anaconda-Server Badge](https://anaconda.org/jmcmurray/req/badges/version.svg)](https://anaconda.org/jmcmurray/req)
 [![Anaconda-Server Badge](https://anaconda.org/jmcmurray/req/badges/downloads.svg)](https://anaconda.org/jmcmurray/req)
 
-A WIP library for HTTP requests in kdb+/q
+HTTP requests library in kdb+/q
 
 kdb+ has built in functions for HTTP requests such as `.Q.hg` (GET) and `.Q.hp`(POST). However, these functions are somewhat limited by several factors. For example, using these functions you cannot supply custom HTTP headers within the requests (for example, authorization tokens that are required by many APIs, a user agent etc.). In addition, in case of an HTTP redirect response, `.Q.hg`/`.Q.hp` will fail.
 
-reQ is a library designed to overcome these limitations for basic HTTP queries. It allows specifying of custom headers where necessary, and also automatically follows HTTP redirects. In addition, in case of JSON response, this will be parsed to KDB+ object automatically.
+reQ is a library designed to overcome these limitations for basic HTTP queries. The main features are:
 
-Additionally, reQ is now compatible with older versions of kdb+/q - there is no reliance on any `.Q` functions found only in more recent versions. For example, `.Q.hg` and `.Q.hp` are only available in version 3.4+, likewise with the underlying `.Q.hap` function etc. reQ does not rely on any of these functions, and therefore works prior to 3.4. It has been tested on version 2.7 and 3.3. `json.k` from kx is provided, and should be loaded when version is below 3.4 to enable JSON decoding on these versions also.
+* Custom headers
+* Automatic following of HTTP redirects
+* Automatic parsing of JSON responses to KDB+ object
+* Support for lower versions of KDB+ (tested on 2.7 & 3.3)
+* Cookie support
 
-Finally, reQ has some very basic cookie support; this will be expanded upon in future updates, but for now, any cookies sent in an HTTP response will be stored in `.req.cookiejar` and will automatically be sent with further requests to the same host. At present, another response sending cookies will overwrite the previous set of cookies in the cookiejar. This functionality is very rudimentary and only suitable for very simple use cases.
+For more details on features & usage, please see the [docs](http://jmcmurray.co.uk/reQ/)
 
-## Usage
+## Getting started
 
-The two main entry point functions within the library are `.req.get` and `.req.post`, replacing `.Q.hg` and `.Q.hp` respectively.
-Other functions are currently undocumented but will be documented in time.
+### Standalone `.q` script
 
-### `.req.get`
+The simplest way for most people to get started with reQ will be via the standalone
+`.q` file available from the [Releases](https://github.com/jonathonmcmurray/reQ/releases)
+tab of this repo. Download the `.q` script from the latest release & this can be loaded
+directly with `\l` when placed in project directory or `QHOME` etc.
 
-Takes two args:
-* URL (can be string, hsym or symbol)
-* Dictionary of HTTP headers
-
-### `.req.post`
-
-Takes three args:
-* URL (can be string, hsym or symbol)
-* Dictionary of HTTP headers
-* Payload (should be a string) -> where necessary, `Content-Type` should be set in header dict manually. `Content-Length` will be added automatically
-
-## Examples
-
-### Custom Headers
-
-```
-$ q req.q                                                                                                                            
-KDB+ 3.5 2017.10.11 Copyright (C) 1993-2017 Kx Systems
-l32/ 2()core 1945MB jonny grizzly 127.0.1.1 NONEXPIRE
-
-q).Q.hg`:http://httpbin.org/headers
-"{\n  \"headers\": {\n    \"Connection\": \"close\", \n    \"Host\": \"httpbin.org\"\n  }\n}\n"
-q).req.get["http://httpbin.org/headers";`custom`headers!("with custom";"values")]
-       | Accept Connection Custom        Headers  Host          User-Agent
--------| -----------------------------------------------------------------
-headers| "*/*"  "close"    "with custom" "values" "httpbin.org" "kdb+/3.5"
-```
-
-### HTTP Redirect
-
-```
-$ q req.q                                                                                                                            
-KDB+ 3.5 2017.10.11 Copyright (C) 1993-2017 Kx Systems
-l32/ 2()core 1945MB jonny grizzly 127.0.1.1 NONEXPIRE
-
-q).Q.hg`:http://httpbin.org/redirect/3
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 3.2 Final//EN\">\n<title>Redirecting...</title>\n<h1>Redirecting...</h1>\n<p>You should be redirected automatica..
-q).req.get["http://httpbin.org/redirect/3";()!()]
+```q
+q)\l req_0.1.3.q
+q).req.g"https://httpbin.org/get"
 args   | (`symbol$())!()
-headers| `Accept`Connection`Host`User-Agent!("*/*";"close";"httpbin.org";"kdb+/3.5")
-origin | "146.199.80.196"
-url    | "http://httpbin.org/get"
+headers| `Accept`Host`User-Agent`X-Amzn-Trace-Id!("*/*";"httpbin.org";"kdb+/3..
+origin | "90.249.33.209"
+url    | "https://httpbin.org/get"
 ```
 
-### POST request
+### qutil package via Anaconda
 
+Alternatively, reQ can be installed as a [qutil](https://github.com/nugend/qutil) via
+[Anaconda](https://www.anaconda.com/)/[Miniconda](https://docs.conda.io/en/latest/miniconda.html)
+
+Assuming conda is installed, installation command is:
+
+```bash
+$ conda install -c jmcmurray req
 ```
-q).req.post["http://httpbin.org/post";enlist["Content-Type"]!enlist .req.ty`json;.j.j (1#`text)!1#`hello]
-args   | (`symbol$())!()
-data   | "{\"text\":\"hello\"}"
-files  | (`symbol$())!()
-form   | (`symbol$())!()
-headers| `Accept`Connection`Content-Length`Content-Type`Host`User-Agent!("*/*";"close";"16";"application/json";"httpbin.org";"kdb+/3.5")
-json   | (,`text)!,"hello"
-origin | "146.199.80.196"
-url    | "http://httpbin.org/post"
+
+And package will then be available in q via:
+
+```q
+q).utl.require"req"
 ```
+
+### Standalone qutil package
+
+If you want to use qutil package, but not via Anaconda, you can also download
+the package as a `.tar.gz` from the [Releases](https://github.com/jonathonmcmurray/reQ/releases)
+tab & extract to your `QPATH` directory.
+
 
 ## Updating documentation with `qDoc`
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cat req/url.q req/cookie.q req/b64.q req/status.q req/req.q req/auth.q req/multipart.q > req_build.q

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,14 @@
 #!/bin/bash
 
-cat req/url.q req/cookie.q req/b64.q req/status.q req/req.q req/auth.q req/multipart.q > req_build.q
+BUILD_VER=${1}
+
+echo Building req_${BUILD_VER}.q...
+cat req/url.q req/cookie.q req/b64.q req/status.q req/req.q req/auth.q req/multipart.q > req_${BUILD_VER}.q
+
+echo Building req-${BUILD_VER}.tar.gz...
+mkdir req-${BUILD_VER}
+cp req/url.q req/cookie.q req/b64.q req/status.q req/req.q req/auth.q req/multipart.q req-${BUILD_VER}/
+tar -czvf req-${BUILD_VER}.tar.gz req-${BUILD_VER}
+rm -r req-${BUILD_VER}
+
+echo Done

--- a/req/auth.q
+++ b/req/auth.q
@@ -17,3 +17,4 @@ getauth:{[h;u] /h-headers,u-URL
   }
 
 \d .
+

--- a/req/b64.q
+++ b/req/b64.q
@@ -16,3 +16,4 @@ enc:@[value;`.Q.btoa;{[x;y]x}enc]
 dec:{(`char$0b sv'8 cut raze 2_'0b vs'`byte$.Q.b6?x) except "\000"}
 
 \d .
+

--- a/req/cookie.q
+++ b/req/cookie.q
@@ -87,3 +87,4 @@ writejar:{[f;j]
   }
 
 \d .
+

--- a/req/doh_google.q
+++ b/req/doh_google.q
@@ -19,3 +19,4 @@ resolve:{[url]
   }
 
 \d .
+

--- a/req/init.q
+++ b/req/init.q
@@ -7,3 +7,4 @@ if[.z.K<=3.1;.utl.pkg"json.q"];                 //add JSON support for older q v
 .utl.pkg"req.q"
 .utl.pkg"auth.q"
 .utl.pkg"multipart.q"
+

--- a/req/multipart.q
+++ b/req/multipart.q
@@ -45,3 +45,4 @@ multi:{[d]
 postmulti:{post[x] . multi y}                                                       //send HTTP POST report with multipart form
 
 \d .
+

--- a/req/req.q
+++ b/req/req.q
@@ -181,3 +181,4 @@ parseresp:{[r]
 .req.del:.req.delete[;;()]
 
 \d .
+

--- a/req/status.q
+++ b/req/status.q
@@ -10,3 +10,4 @@ class:{c:div[;100];$[0=type x;.z.s[first x];99=type x;c x`status;c x]}          
 /TODO: add dict of status codes
 
 \d .
+

--- a/req/timeout.q
+++ b/req/timeout.q
@@ -18,3 +18,4 @@ timeout:{[t;m;u;hd;p]
   }
 
 \d .
+

--- a/req/url.q
+++ b/req/url.q
@@ -86,3 +86,6 @@ enc:{[d]
 dec:{[x]
   :(!/)"S=&"0:.h.uh ssr[x;"+";" "];                                                 //parse incoming request into dict, replace escaped chars
   }
+
+\d .
+

--- a/tests/test_requests.q
+++ b/tests/test_requests.q
@@ -38,3 +38,4 @@
         r mustmatch .req.g"http://httpbin.org/cookies/delete?abc";
     }
  };
+


### PR DESCRIPTION
Adding a script to build a single `.q` file that can be loaded simply without the need for qutil etc.

Aim is to simplify use in other projects etc. where `.q` file can simply be included (or placed in `$QHOME` dir etc.).

### To do

- [x] Make output script include version number
- [x] Document building & using
- [ ] Modify tests in some way to allow testing both qutil package & unified script