### PR TITLE
Strip autodoc comments when building

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ output table `t`.
 ## Building releases
 
 To build a release, `build.sh` is used. The script creates the unified, standalone
-`.q` script & the `.tar.gz` of qutil package.
+`.q` script (with qdoc comments stripped)  & the `.tar.gz` of qutil package.
 
 Argument is version number e.g.
 

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,7 @@ BUILD_VER=${1}
 
 echo Building req_${BUILD_VER}.q...
 cat req/ext/os.q req/url.q req/cookie.q req/b64.q req/status.q req/req.q req/auth.q req/multipart.q > req_${BUILD_VER}.q
+sed -i '/^\/\/ @/d' req_${BUILD_VER}.q
 
 echo Building req-${BUILD_VER}.tar.gz...
 mkdir -p req-${BUILD_VER}/ext


### PR DESCRIPTION
Strip out the comments used to auto-generate docs with qdoc when building standalone `.q` file